### PR TITLE
Add ability to extend Prometheus scrape targets + includes cf cartel changes from Andriy

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,6 +23,7 @@ RUN curl -L -Os https://github.com/thanos-io/thanos/releases/download/v${THANOS_
 FROM alpine:latest
 LABEL maintainer="andy.lo-a-foe@philips.com"
 RUN apk add --update supervisor jq && rm  -rf /tmp/* /var/cache/apk/*
+RUN apk add yq --repository http://dl-cdn.alpinelinux.org/alpine/edge/community
 RUN mkdir -p /sidecars/bin /sidecars/supervisor/conf.d sidecars/etc
 RUN mkdir -p /prometheus /thanos
 COPY --from=prometheus /app/prometheus /sidecars/bin
@@ -30,7 +31,9 @@ COPY --from=thanos     /app/thanos     /sidecars/bin
 COPY prometheus.yml  /sidecars/etc
 COPY prometheus.conf /sidecars/supervisor/conf.d
 COPY thanos.conf /sidecars/supervisor/conf.d
-COPY scripts/thanos_s3.sh /sidecars/bin
+COPY scripts/ /sidecars/bin
+RUN sh -c "chmod +x /sidecars/bin/thanos_s3.sh"
+RUN sh -c "chmod +x /sidecars/bin/prometheus_targets.sh"
 
 EXPOSE 9090
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN curl -L -Os https://github.com/thanos-io/thanos/releases/download/v${THANOS_
 
 FROM alpine:latest
 LABEL maintainer="andy.lo-a-foe@philips.com"
-RUN apk add --update supervisor jq && rm  -rf /tmp/* /var/cache/apk/*
+RUN apk add --update supervisor jq curl && rm -rf /tmp/* /var/cache/apk/*
 RUN apk add yq --repository http://dl-cdn.alpinelinux.org/alpine/edge/community
 RUN mkdir -p /sidecars/bin /sidecars/supervisor/conf.d sidecars/etc
 RUN mkdir -p /prometheus /thanos

--- a/docker/Dockerfile_with_exporter
+++ b/docker/Dockerfile_with_exporter
@@ -29,6 +29,7 @@ RUN curl -L -Os https://github.com/thanos-io/thanos/releases/download/v${THANOS_
 FROM alpine:latest
 LABEL maintainer="andy.lo-a-foe@philips.com"
 RUN apk add --update supervisor jq && rm  -rf /tmp/* /var/cache/apk/*
+RUN apk add yq --repository http://dl-cdn.alpinelinux.org/alpine/edge/community
 RUN mkdir -p /sidecars/bin /sidecars/supervisor/conf.d sidecars/etc
 RUN mkdir -p /prometheus /thanos
 COPY --from=prometheus /app/prometheus /sidecars/bin
@@ -38,7 +39,9 @@ COPY prometheus.yml  /sidecars/etc
 COPY cf_exporter.conf /sidecars/supervisor/conf.d
 COPY prometheus.conf /sidecars/supervisor/conf.d
 COPY thanos.conf /sidecars/supervisor/conf.d
-COPY scripts/thanos_s3.sh /sidecars/bin
+COPY scripts/ /sidecars/bin
+RUN sh -c "chmod +x /sidecars/bin/thanos_s3.sh"
+RUN sh -c "chmod +x /sidecars/bin/prometheus_targets.sh"
 
 EXPOSE 9090
 

--- a/docker/Dockerfile_with_exporter
+++ b/docker/Dockerfile_with_exporter
@@ -28,7 +28,7 @@ RUN curl -L -Os https://github.com/thanos-io/thanos/releases/download/v${THANOS_
 
 FROM alpine:latest
 LABEL maintainer="andy.lo-a-foe@philips.com"
-RUN apk add --update supervisor jq && rm  -rf /tmp/* /var/cache/apk/*
+RUN apk add --update supervisor jq curl && rm -rf /tmp/* /var/cache/apk/*
 RUN apk add yq --repository http://dl-cdn.alpinelinux.org/alpine/edge/community
 RUN mkdir -p /sidecars/bin /sidecars/supervisor/conf.d sidecars/etc
 RUN mkdir -p /prometheus /thanos

--- a/docker/prometheus.conf
+++ b/docker/prometheus.conf
@@ -1,5 +1,5 @@
 [program:prometheus]
-command = /sidecars/bin/prometheus --config.file=/sidecars/etc/prometheus.yml --storage.tsdb.path=/prometheus --storage.tsdb.retention=2d --storage.tsdb.min-block-duration=30m --storage.tsdb.max-block-duration=30m --web.enable-lifecycle
+command = /sidecars/bin/prometheus_targets.sh --config.file=/sidecars/etc/prometheus.yml --storage.tsdb.path=/prometheus --storage.tsdb.retention=2d --storage.tsdb.min-block-duration=30m --storage.tsdb.max-block-duration=30m --web.enable-lifecycle
 autostart = true
 autorestart = true
 startsecs = 5

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -37,3 +37,8 @@ scrape_configs:
       - targets: ['localhost:18080']
         labels:
           group: 'cf'
+
+  - job_name: cartel 
+    file_sd_configs:
+      - files:
+        - /sidecars/etc/targets.json

--- a/docker/scripts/prometheus_targets.sh
+++ b/docker/scripts/prometheus_targets.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+set -e
+
+# Generate file to merge into actual config file
+echo $PROMETHEUS_TARGETS | base64 -d >> /sidecars/etc/configured_targets.yml
+
+# Merge the two yaml files together, overwriting prometheus.yml in place
+yq m --inplace --arrays append /sidecars/etc/prometheus.yml /sidecars/etc/configured_targets.yml
+
+# Start and run prometheus
+exec /sidecars/bin/prometheus "$@"

--- a/docker/scripts/prometheus_targets.sh
+++ b/docker/scripts/prometheus_targets.sh
@@ -7,5 +7,13 @@ echo $PROMETHEUS_TARGETS | base64 -d >> /sidecars/etc/configured_targets.yml
 # Merge the two yaml files together, overwriting prometheus.yml in place
 yq m --inplace --arrays append /sidecars/etc/prometheus.yml /sidecars/etc/configured_targets.yml
 
+# Things for Cartel
+json_tmpl_file="tmpl_targets"
+json_file="targets.json"
+echo $CARTEL_HOSTS | tr "," "\n" > hosts
+echo '[{"targets": '`cat hosts| jq -R -s -c 'split("\n")[:-1]'`', "labels":{"group":"cartel"}}]'  > $json_tmpl_file
+cat $json_tmpl_file | jq . > $json_file
+mv $json_file /sidecars/etc/
+
 # Start and run prometheus
 exec /sidecars/bin/prometheus "$@"

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,8 @@ output "thanos_space_id" {
   description = "Cloud foundry space ID of Thanos"
   value       = cloudfoundry_space.space.id
 }
+
+output "thanos_app_id" {
+  description = "App id for Thanos"
+  value = cloudfoundry_app.thanos.id
+}


### PR DESCRIPTION
Enables specifying your own extended prometheus targets (targets only) by supplying the PROMETHEUS_TARGETS env. variable with a base64 encoded value containing any number of additional scrape-targets.
The contents of which could look like this:
`c2NyYXBlX2NvbmZpZ3M6DQogIC0gam9iX25hbWU6IC.....` (abr., because base64 is long :))
Just transform this into base64:
```json
scrape_configs:
  - job_name: "promregator"
    scheme: http
    metrics_path: /metrics
    static_configs:
      - targets: ["promregator-phc-dev.apps.internal:8080"]
```

This also includes changes from Andriy which enable cartel targets (there's a PR for it, which has been stale forever, so included it here instead.)