### PR TITLE
Allowed Grafana to be internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ module "thanos" {
 | environment | Pass environment variable to the app | `map` | `{}` | no |
 | grafana\_environment | Pass environment variable to Grafana | `map` | `{}` | no |
 | grafana\_image | Image to use for Grafana | `string` | `"grafana/grafana:latest"` | no |
+| grafana\_public\_endpoints | Make Grafana endpoints private(false) or public (true) | `bool` | `true` | no |
 | name\_postfix | The postfix string to append to the space, hostname, etc. Prevents namespace clashes | `string` | `""` | no |
 | thanos\_image | Image to use for Thanos app | `string` | `"philipslabs/cf-thanos:latest"` | no |
 | thanos\_query\_image | Image to use for Thanos query | `string` | `"philipslabs/cf-thanos:latest"` | no |

--- a/grafana.tf
+++ b/grafana.tf
@@ -7,7 +7,7 @@ module "grafana" {
   grafana_image   = var.grafana_image
   cf_space        = cloudfoundry_space.space.name
   cf_org          = data.cloudfoundry_org.org.name
-  cf_domain       = data.cloudfoundry_domain.app_domain.name
+  cf_domain       = var.grafana_public_endpoints ? data.cloudfoundry_domain.app_domain.name : data.cloudfoundry_domain.apps_internal_domain
   name_postfix    = local.postfix_name
   environment     = var.grafana_environment
   network_policies = [

--- a/variables.tf
+++ b/variables.tf
@@ -62,6 +62,12 @@ variable "grafana_image" {
   type        = string
 }
 
+variable "grafana_public_endpoints" {
+  description = "Make Grafana public endpoint"
+  type        = bool
+  default     = true
+}
+
 variable "environment" {
   type        = map
   description = "Pass environment variable to the app"


### PR DESCRIPTION
Make the provision for Grafana to be on an internal domain so that other access provisions can be made.

In my use case I have provisioned oaut2_proxy to secure both Thanos and Grafana with the same security.