### PR TITLE
Alert manager on path

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_alertmanager_config"></a> [alertmanager\_config](#input\_alertmanager\_config) | Alertmanager config | `string` | `""` | no |
-| <a name="input_alertmanager_image"></a> [alertmanager\_image](#input\_alertmanager\_image) | Image to use for Alertmanager | `string` | `"prom/alertmanager:v0.23.0"` | no |
+| <a name="input_alertmanager"></a> [alertmanager](#input\_alertmanager) | n/a | <pre>object({<br>    docker_image    = optional(string)<br>    memory          = optional(string)<br>    config_file     = optional(string)<br>    docker_username = optional(string)<br>    docker_password = optional(string)<br>  })</pre> | `{}` | no |
 | <a name="input_cf_functional_account"></a> [cf\_functional\_account](#input\_cf\_functional\_account) | Configuration for the CloudFoundry function account. Required for variant and if enable\_cf\_exporter is set to true | <pre>object({<br>    api_endpoint = string<br>    username     = string<br>    password     = string<br>  })</pre> | <pre>{<br>  "api_endpoint": "",<br>  "password": "",<br>  "username": ""<br>}</pre> | no |
 | <a name="input_cf_org_name"></a> [cf\_org\_name](#input\_cf\_org\_name) | Cloudfoundry ORG name to use for reverse proxy | `string` | n/a | yes |
 | <a name="input_cf_paas_exporter_disk_quota"></a> [cf\_paas\_exporter\_disk\_quota](#input\_cf\_paas\_exporter\_disk\_quota) | CF PaaS Exporter disk quota | `number` | `100` | no |

--- a/alertmanager.tf
+++ b/alertmanager.tf
@@ -43,7 +43,7 @@ resource "cloudfoundry_app" "alertmanager" {
   environment = merge({
     ALERTMANAGER_CONFIG_BASE64 = base64encode(local.alertmanager_config)
   }, var.environment)
-  command = "echo $ALERTMANAGER_CONFIG_BASE64 | base64 -d > /etc/alertmanager/alertmanager.yml && /bin/alertmanager --config.file=/etc/alertmanager/alertmanager.yml --storage.path=/alertmanager"
+  command = "echo $ALERTMANAGER_CONFIG_BASE64 | base64 -d > /etc/alertmanager/alertmanager.yml && /bin/alertmanager --config.file=/etc/alertmanager/alertmanager.yml --storage.path=/alertmanager --web.route-prefix=/alertmanager"
 
   dynamic "routes" {
     for_each = local.alertmanager_routes

--- a/alertmanager.tf
+++ b/alertmanager.tf
@@ -37,8 +37,8 @@ resource "cloudfoundry_app" "alertmanager" {
   disk_quota   = 2048
   docker_image = local.alertmanager.docker_image
   docker_credentials = {
-    username = var.docker_username
-    password = var.docker_password
+    username = local.alertmanager.docker_username
+    password = local.alertmanager.docker_password
   }
   environment = merge({
     ALERTMANAGER_CONFIG_BASE64 = base64encode(local.alertmanager_config)

--- a/alertmanager.tf
+++ b/alertmanager.tf
@@ -3,7 +3,7 @@ locals {
 
   webhook_url = var.teams_incoming_webhook_url != "" ? "http://${cloudfoundry_route.prometheusmsteams_internal[0].endpoint}:2000/alertmanager" : "http://localhost:5001"
 
-  alertmanager_config = var.alertmanager_config == "" ? templatefile("${path.module}/templates/alertmanager.yml", { url = local.webhook_url }) : var.alertmanager_config
+  alertmanager_config = local.alertmanager.config_file == "" ? templatefile("${path.module}/templates/alertmanager.yml", { url = local.webhook_url }) : var.alertmanager.config_file
 }
 
 resource "cloudfoundry_app" "prometheusmsteams" {
@@ -33,9 +33,9 @@ resource "cloudfoundry_route" "prometheusmsteams_internal" {
 resource "cloudfoundry_app" "alertmanager" {
   name         = "tf-alertmanager-${local.postfix}"
   space        = var.cf_space_id
-  memory       = 512
+  memory       = local.alertmanager.memory
   disk_quota   = 2048
-  docker_image = var.alertmanager_image
+  docker_image = local.alertmanager.docker_image
   docker_credentials = {
     username = var.docker_username
     password = var.docker_password

--- a/alertmanager.tf
+++ b/alertmanager.tf
@@ -3,7 +3,7 @@ locals {
 
   webhook_url = var.teams_incoming_webhook_url != "" ? "http://${cloudfoundry_route.prometheusmsteams_internal[0].endpoint}:2000/alertmanager" : "http://localhost:5001"
 
-  alertmanager_config = local.alertmanager.config_file == "" ? templatefile("${path.module}/templates/alertmanager.yml", { url = local.webhook_url }) : var.alertmanager.config_file
+  alertmanager_config = local.alertmanager.config_file == "" ? templatefile("${path.module}/templates/alertmanager.yml", { url = local.webhook_url }) : local.alertmanager.config_file
 }
 
 resource "cloudfoundry_app" "prometheusmsteams" {

--- a/templates/prometheus.yml
+++ b/templates/prometheus.yml
@@ -10,6 +10,7 @@ global:
 alerting:
   alertmanagers:
   - scheme: http
+    path_prefix: "/alertmanager/"
     static_configs:
     - targets:
 %{ for alertmanager in alertmanagers ~}

--- a/variables.tf
+++ b/variables.tf
@@ -144,9 +144,11 @@ variable "cf_paas_exporter_disk_quota" {
 
 variable "alertmanager" {
   type = object({
-    docker_image = optional(string)
-    memory       = optional(string)
-    config_file  = optional(string)
+    docker_image    = optional(string)
+    memory          = optional(string)
+    config_file     = optional(string)
+    docker_username = optional(string)
+    docker_password = optional(string)
   })
   default = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -32,18 +32,6 @@ variable "thanos_store_image" {
   type        = string
 }
 
-variable "alertmanager_image" {
-  description = "Image to use for Alertmanager"
-  default     = "prom/alertmanager:v0.23.0"
-  type        = string
-}
-
-variable "alertmanager_config" {
-  description = "Alertmanager config"
-  default     = ""
-  type        = string
-}
-
 variable "teams_incoming_webhook_url" {
   description = "Teams incoming webhook URL"
   default     = ""
@@ -152,4 +140,21 @@ variable "cf_paas_exporter_disk_quota" {
   type        = number
   description = "CF PaaS Exporter disk quota"
   default     = 100
+}
+
+variable "alertmanager" {
+  type = object({
+    docker_image = optional(string)
+    memory       = optional(string)
+    config_file  = optional(string)
+  })
+  default = {}
+}
+
+locals {
+  alertmanager = defaults(var.alertmanager, {
+    memory       = 128
+    docker_image = "prom/alertmanager:v0.23.0"
+    config_file  = ""
+  })
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,6 @@
 terraform {
   required_version = ">= 0.13.0"
+  experiments      = [module_variable_optional_attrs]
 
   required_providers {
     cloudfoundry = {


### PR DESCRIPTION
Make alert manager run on a path so that it can be routed to by path

Id like alert manager to run on a path so it can be routed to on the same domain as a prometheus and grafana instance.

I don't think this makes much impact to the existing config as alertmanager is internal by default in this module.

By making this the default it prevents the need for extra config to account for this use.