### PR TITLE
Allow being provided a list of services to bound to the apps

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,14 @@ resource "cloudfoundry_app" "thanos" {
   service_binding {
     service_instance = cloudfoundry_service_instance.s3.id
   }
+
+  dynamic "service_binding" {
+    for_each = var.thanos_service_bindings
+
+    content {
+      service_instance = service_binding.value.service_instance
+    }
+  }
 }
 
 resource "cloudfoundry_route" "thanos" {

--- a/thanos_query.tf
+++ b/thanos_query.tf
@@ -21,6 +21,14 @@ resource "cloudfoundry_app" "thanos_query" {
       route = routes.value
     }
   }
+
+  dynamic "service_binding" {
+    for_each = var.thanos_query_service_bindings
+
+    content {
+      service_instance = service_binding.value.service_instance
+    }
+  }
 }
 
 resource "cloudfoundry_route" "thanos_query" {

--- a/thanos_store.tf
+++ b/thanos_store.tf
@@ -16,6 +16,13 @@ resource "cloudfoundry_app" "thanos_store" {
   service_binding {
     service_instance = cloudfoundry_service_instance.s3.id
   }
+  dynamic "service_binding" {
+    for_each = var.thanos_store_service_bindings
+
+    content {
+      service_instance = service_binding.value.service_instance
+    }
+  }
 }
 
 resource "cloudfoundry_route" "thanos_store_internal" {

--- a/variables.tf
+++ b/variables.tf
@@ -154,12 +154,6 @@ variable "thanos_query_service_bindings" {
   default     = []
 }
 
-variable "thanos_query_service_bindings" {
-  type        = list(object({ service_instance = string }))
-  description = "A list of service instances that should be bound to the thanos_query app"
-  default     = []
-}
-
 variable "thanos_store_service_bindings" {
   type        = list(object({ service_instance = string }))
   description = "A list of service instances that should be bound to the thanos_store app"

--- a/variables.tf
+++ b/variables.tf
@@ -141,3 +141,27 @@ variable "alertmanagers_endpoints" {
   description = "List of endpoints of the alert managers"
   default     = []
 }
+
+variable "thanos_service_bindings" {
+  type        = list(object({ service_instance = string }))
+  description = "A list of service instances that should be bound to the thanos app"
+  default     = []
+}
+
+variable "thanos_query_service_bindings" {
+  type        = list(object({ service_instance = string }))
+  description = "A list of service instances that should be bound to the thanos app"
+  default     = []
+}
+
+variable "thanos_query_service_bindings" {
+  type        = list(object({ service_instance = string }))
+  description = "A list of service instances that should be bound to the thanos_query app"
+  default     = []
+}
+
+variable "thanos_store_service_bindings" {
+  type        = list(object({ service_instance = string }))
+  description = "A list of service instances that should be bound to the thanos_store app"
+  default     = []
+}


### PR DESCRIPTION
I'm adding a variable to be possible to provide a list of services to be bound to the apps. Such a feature is needed for example to send the apps logs to the log bucket.